### PR TITLE
NXP index xml added to index examples on Application Code Hub

### DIFF
--- a/dm-wolfmqtt-publisher-client-with-zephyr/dm-wolfmqtt-publisher-client-with-zephyr.xml
+++ b/dm-wolfmqtt-publisher-client-with-zephyr/dm-wolfmqtt-publisher-client-with-zephyr.xml
@@ -1,0 +1,26 @@
+<data:item xmlns:data="data" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="data ../../xsd/alp.xsd" type="demo" format="zephyr" versionSchema="1.0.0" name="wolfmqtt publisher client with zephyr" uuid="3968491f-d621-4244-a4ce-89e2ad02c54a">
+    <display_title>
+        wolfSSL MQTT AWS Test using Zephyr RTOS
+    </display_title>
+    <overview>
+        <![CDATA[This demo demostrate capabilities of new FRDM-MCXN947.<br><a href="https://github.com/wolfSSL/nxp-appcodehub/tree/main/dm-wolfmqtt-publisher-client-with-zephyr#demo"></a>Simple connects to an AWS broker subscribes, and publishes a message.]]>
+    </overview>
+    <toolchains>
+        <toolchain name="vscode"></toolchain>
+    </toolchains>
+    <families>
+        <family name="mcx"></family>
+    </families>
+    <nxp_compatible_hw>
+        <hw id="FRDM-MCXN947"></hw>
+    </nxp_compatible_hw>
+    <peripherals>
+        <peripheral name="uart"></peripheral>
+        <peripheral name="ethernet"></peripheral>
+    </peripherals>
+    <categories>
+        <category name="cc_devices"></category>
+        <category name="wireless_connectivity"></category>
+        <category name="networking"></category>
+    </categories>
+</data:item>

--- a/dm-wolfssh-rgb-server-with-zephyr/dm-wolfssh-rgb-server-with-zephyr.xml
+++ b/dm-wolfssh-rgb-server-with-zephyr/dm-wolfssh-rgb-server-with-zephyr.xml
@@ -1,0 +1,26 @@
+<data:item xmlns:data="data" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="data ../../xsd/alp.xsd" type="demo" format="zephyr" versionSchema="1.0.0" name="wolfssh rgb server with zephyr" uuid="ee743cbe-b7bc-483f-ac1c-80a3bfc8f05c">
+    <display_title>
+        wolfSSH RGB Server using Zephyr RTOS
+    </display_title>
+    <overview>
+        <![CDATA[This demo demostrates capabilities of new FRDM-MCXN947.<br><a href="https://github.com/wolfSSL/nxp-appcodehub/tree/main/dm-wolfssh-rgb-server-with-zephyr#demo"></a>Creating a simple server using the Zephyr RTOS and wolfSSL to utilize the networking capabilities of the FRDM-MCXN947 through its ethernet port.]]>
+    </overview>
+    <toolchains>
+        <toolchain name="vscode"></toolchain>
+    </toolchains>
+    <families>
+        <family name="mcx"></family>
+    </families>
+    <nxp_compatible_hw>
+        <hw id="FRDM-MCXN947"></hw>
+    </nxp_compatible_hw>
+    <peripherals>
+        <peripheral name="ethernet"></peripheral>
+        <peripheral name="uart"></peripheral>
+    </peripherals>
+    <categories>
+        <category name="networking"></category>
+        <category name="cc_devices"></category>
+        <category name="rtos"></category>
+    </categories>
+</data:item>

--- a/dm-wolfssl-tls-hello-server-with-zephyr/dm-wolfssl-tls-hello-server-with-zephyr.xml
+++ b/dm-wolfssl-tls-hello-server-with-zephyr/dm-wolfssl-tls-hello-server-with-zephyr.xml
@@ -1,0 +1,25 @@
+<data:item xmlns:data="data" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="data ../../xsd/alp.xsd" type="demo" format="zephyr" versionSchema="1.0.0" name="wolfssl tls hello server with zephyr" uuid="ec02bcb0-84bc-4dcb-9098-bdaba3d2d7e1">
+    <display_title>
+        wolfSSL TLSv1.3 Hello Server using Zephyr RTOS
+    </display_title>
+    <overview>
+        <![CDATA[Creating a simple server using the Zephyr RTOS and wolfSSL to utilize the networking capabilities of the FRDM-MCXN947 through its ethernet port.]]>
+    </overview>
+    <toolchains>
+        <toolchain name="vscode"></toolchain>
+    </toolchains>
+    <families>
+        <family name="mcx"></family>
+    </families>
+    <nxp_compatible_hw>
+        <hw id="FRDM-MCXN947"></hw>
+    </nxp_compatible_hw>
+    <peripherals>
+        <peripheral name="ethernet"></peripheral>
+        <peripheral name="uart"></peripheral>
+    </peripherals>
+    <categories>
+        <category name="networking"></category>
+        <category name="rtos"></category>
+    </categories>
+</data:item>


### PR DESCRIPTION
The NXP server uses the xml for metadata to identify and index the examples.  Added for 3 WolfSSL examples